### PR TITLE
Add EOL, Movebank and Zooniverse to biology resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,9 @@ Tools
 * [BioPython](http://biopython.org/wiki/Main_Page), Python libraries that implement a rich set of modules to handle wide class of biological computations
 * [SciFeeds](https://scifeeds.com/), Aggregates science mentioned in articles, social media, and news media to help identify important scientific advances
 * [Linuxbrew](http://linuxbrew.sh/), port of Homebrew, a Mac OS package manager, for Linux
+* [Encyclopedia of Life (EOL)](https://eol.org), Aggregates species data from 1,000+ institutions with a free API covering 2.7M+ taxa
+* [Movebank](https://www.movebank.org), Open repository for animal movement ecology data including GPS and accelerometer tracks, with a free API
+* [Zooniverse Biology Projects](https://www.zooniverse.org/projects), Citizen science platform hosting wildlife annotation and classification projects
 
 Journals
 --------


### PR DESCRIPTION
Three open-data resources that fill a notable gap in the Tools section — the list currently covers analysis software and libraries but lacks entries for large-scale biological databases and citizen science platforms.

**Encyclopedia of Life (EOL)** — https://eol.org
Aggregates species data from 1,000+ partner institutions (Smithsonian, iNaturalist, Catalogue of Life, etc.) covering 2.7M+ taxa. Free API with JSON/XML output. Widely used as a reference database in biodiversity informatics.

**Movebank** — https://www.movebank.org
Open repository for animal movement ecology data: GPS tracks, accelerometer data, and associated metadata for hundreds of species. Free API for data access and upload. Hosted by the Max Planck Institute.

**Zooniverse Biology Projects** — https://www.zooniverse.org/projects
Citizen science platform hosting numerous wildlife annotation, species identification, and ecological classification projects. Biology-focused projects have produced peer-reviewed datasets used in population ecology and conservation research.

All three are freely accessible, have APIs or downloadable datasets, and are referenced in the primary literature.