### PR TITLE
Add Chesser Resources and Learro to General Biology

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ General Biology
 * [The Developing Genome: An Introduction to Behavioral Epigenetics by *Davis S. Moore*](https://global.oup.com/academic/product/the-developing-genome-9780199922345?cc=us&lang=en&)
 * [The Systems View of Life: A Unifying Vision](https://www.amazon.com/Systems-View-Life-Unifying-Vision-ebook/dp/B00I0UNCES/ref=mt_kindle?_encoding=UTF8&me=)
 * [Scitable by *Nature Education*](https://idp.nature.com/authorize?response_type=cookie&client_id=grover&redirect_uri=http%3A%2F%2Fwww.nature.com%2Fscitable)
+* [Learro](https://learro.com/) — Free AP Biology study guides, practice exams, and reference materials.
+* [Chesser Resources](https://chesserresources.com.au/new/) — Free document-sharing platform with biology notes and exam papers. Free signup required.
 * [The Many Phases of the Matter by *Ganeshan Venkataraman*](https://www.goodreads.com/book/show/2205012.The_Many_Phases_Of_Matter)
 * [The Shaping of Life by *Lionel G. Harrison*](https://www.cambridge.org/core/books/the-shaping-of-life/CC2A60300A688A6BE31BE73DBF420A95)
 * [The Machinery of Life by *David Goodsell*](http://mgl.scripps.edu/people/goodsell/books/MoL2-preview.html)


### PR DESCRIPTION
Adds two free educational resources to the Tutorials section:

- **[Chesser Resources](https://chesserresources.com.au/new/)** — Free document-sharing platform: study notes, exam papers (JEE Mains, CBSE), and subject notes. Free signup required for downloads (anti-bot, no paywall — site has no pricing page).
- **[Learro](https://learro.com/)** — Free AP exam prep: study guides, practice exams, formula sheets, and scoring guidelines. No signup or paywall.